### PR TITLE
Add small text rendering for overstacked items

### DIFF
--- a/fabric-client/src/main/java/org/samo_lego/clientstorage/fabric_client/mixin/screen/MAbstractContainerScreen.java
+++ b/fabric-client/src/main/java/org/samo_lego/clientstorage/fabric_client/mixin/screen/MAbstractContainerScreen.java
@@ -1,10 +1,14 @@
 package org.samo_lego.clientstorage.fabric_client.mixin.screen;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.math.Matrix4f;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.inventory.Slot;
@@ -42,15 +46,15 @@ public class MAbstractContainerScreen extends Screen {
 
     @ModifyVariable(method = "renderSlot", at = @At(value = "STORE"))
     private String changeItemCountLabel(String label) {
+        this.renderWithSmallText = false; // Use normal-sized text for normal slots
         if (this.slot instanceof RemoteSlot) {
+            this.renderWithSmallText = true; // Use small text for remote slots
+
             // Custom count label
             int count = this.slot.getItem().getCount();
 
-            this.renderWithSmallText = false; // Use normal-sized text for small numbers
-
             // Use physics notation for large numbers
             if (count >= 1000) {
-                this.renderWithSmallText = true; // Use small text for large numbers
                 int exp = (int) (Math.log(count) / Math.log(1000));
                 return String.format("%.1f%c", count / Math.pow(1000, exp), UNITS.charAt(exp - 1));
             }
@@ -59,15 +63,18 @@ public class MAbstractContainerScreen extends Screen {
     }
 
     @Redirect(method = "renderSlot", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/ItemRenderer;renderGuiItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V"))
-    private void renderGuiItemWithDifferentTextSize(ItemRenderer itemRenderer, Font fontRenderer, ItemStack stack, int x, int y, @Nullable String countLabel) {
-        if(renderWithSmallText) {
-            itemRenderer.renderGuiItem(stack, x, y); // Render Normally without count label
-            PoseStack textMatrixStack = new PoseStack(); // Create new matrix stack for transforming text size
-            textMatrixStack.scale(0.5F, 0.5F, 1); // Scale matrix stack to make text smaller
-            textMatrixStack.translate(0, 0, itemRenderer.blitOffset + itemRenderer.ITEM_COUNT_BLIT_OFFSET); // Offset text z position so that it is in front of item
-            fontRenderer.drawShadow(textMatrixStack, countLabel, x * 2 + 31 - fontRenderer.width(countLabel), y * 2 + 23, ChatFormatting.WHITE.getColor()); // Render count label
-        } else {
-            itemRenderer.renderGuiItemDecorations(fontRenderer, stack, x, y, countLabel); // Render Normally
+    private void renderGuiItemDecorationsWithDifferentTextSize(ItemRenderer itemRenderer, Font fontRenderer, ItemStack stack, int x, int y, @Nullable String countLabel) {
+        if (!stack.isEmpty()) { // Ensure ItemStack isn't empty before decorating
+            if (renderWithSmallText) {
+                itemRenderer.renderGuiItemDecorations(fontRenderer, stack, x, y, ""); // Render other Decorations
+                countLabel = countLabel == null ? String.valueOf(stack.getCount()) : countLabel; // Get count string if countLabel is null
+                PoseStack textMatrixStack = new PoseStack(); // Create new matrix stack for transforming text size
+                textMatrixStack.scale(0.5F, 0.5F, 1); // Scale matrix stack to make text smaller
+                textMatrixStack.translate(0, 0, itemRenderer.blitOffset + itemRenderer.ITEM_COUNT_BLIT_OFFSET); // Offset text z position so that it is in front of item
+                fontRenderer.drawShadow(textMatrixStack, countLabel, x * 2 + 31 - fontRenderer.width(countLabel), y * 2 + 23, ChatFormatting.WHITE.getColor()); // Render count label
+            } else {
+                itemRenderer.renderGuiItemDecorations(fontRenderer, stack, x, y, countLabel); // Render Decorations Normally
+            }
         }
     }
 }

--- a/fabric-client/src/main/java/org/samo_lego/clientstorage/fabric_client/mixin/screen/MAbstractContainerScreen.java
+++ b/fabric-client/src/main/java/org/samo_lego/clientstorage/fabric_client/mixin/screen/MAbstractContainerScreen.java
@@ -1,16 +1,22 @@
 package org.samo_lego.clientstorage.fabric_client.mixin.screen;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
 import org.samo_lego.clientstorage.fabric_client.inventory.RemoteSlot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(AbstractContainerScreen.class)
@@ -21,6 +27,9 @@ public class MAbstractContainerScreen extends Screen {
 
     @Unique
     private Slot slot;
+
+    @Unique
+    boolean renderWithSmallText;
 
     protected MAbstractContainerScreen(Component component) {
         super(component);
@@ -37,12 +46,28 @@ public class MAbstractContainerScreen extends Screen {
             // Custom count label
             int count = this.slot.getItem().getCount();
 
+            this.renderWithSmallText = false; // Use normal-sized text for small numbers
+
             // Use physics notation for large numbers
             if (count >= 1000) {
+                this.renderWithSmallText = true; // Use small text for large numbers
                 int exp = (int) (Math.log(count) / Math.log(1000));
                 return String.format("%.1f%c", count / Math.pow(1000, exp), UNITS.charAt(exp - 1));
             }
         }
         return label;
+    }
+
+    @Redirect(method = "renderSlot", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/ItemRenderer;renderGuiItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V"))
+    private void renderGuiItemWithDifferentTextSize(ItemRenderer itemRenderer, Font fontRenderer, ItemStack stack, int x, int y, @Nullable String countLabel) {
+        if(renderWithSmallText) {
+            itemRenderer.renderGuiItem(stack, x, y); // Render Normally without count label
+            PoseStack textMatrixStack = new PoseStack(); // Create new matrix stack for transforming text size
+            textMatrixStack.scale(0.5F, 0.5F, 1); // Scale matrix stack to make text smaller
+            textMatrixStack.translate(0, 0, itemRenderer.blitOffset + itemRenderer.ITEM_COUNT_BLIT_OFFSET); // Offset text z position so that it is in front of item
+            fontRenderer.drawShadow(textMatrixStack, countLabel, x * 2 + 31 - fontRenderer.width(countLabel), y * 2 + 23, ChatFormatting.WHITE.getColor()); // Render count label
+        } else {
+            itemRenderer.renderGuiItemDecorations(fontRenderer, stack, x, y, countLabel); // Render Normally
+        }
     }
 }

--- a/fabric-client/src/main/java/org/samo_lego/clientstorage/fabric_client/mixin/screen/MAbstractContainerScreen.java
+++ b/fabric-client/src/main/java/org/samo_lego/clientstorage/fabric_client/mixin/screen/MAbstractContainerScreen.java
@@ -67,11 +67,13 @@ public class MAbstractContainerScreen extends Screen {
         if (!stack.isEmpty()) { // Ensure ItemStack isn't empty before decorating
             if (renderWithSmallText) {
                 itemRenderer.renderGuiItemDecorations(fontRenderer, stack, x, y, ""); // Render other Decorations
-                countLabel = countLabel == null ? String.valueOf(stack.getCount()) : countLabel; // Get count string if countLabel is null
-                PoseStack textMatrixStack = new PoseStack(); // Create new matrix stack for transforming text size
-                textMatrixStack.scale(0.5F, 0.5F, 1); // Scale matrix stack to make text smaller
-                textMatrixStack.translate(0, 0, itemRenderer.blitOffset + itemRenderer.ITEM_COUNT_BLIT_OFFSET); // Offset text z position so that it is in front of item
-                fontRenderer.drawShadow(textMatrixStack, countLabel, x * 2 + 31 - fontRenderer.width(countLabel), y * 2 + 23, ChatFormatting.WHITE.getColor()); // Render count label
+                if (stack.getCount() > 1) { // Only render amount text if stack has more than 1 item
+                    countLabel = countLabel == null ? String.valueOf(stack.getCount()) : countLabel; // Get count string if countLabel is null
+                    PoseStack textMatrixStack = new PoseStack(); // Create new matrix stack for transforming text size
+                    textMatrixStack.scale(0.5F, 0.5F, 1); // Scale matrix stack to make text smaller
+                    textMatrixStack.translate(0, 0, itemRenderer.blitOffset + itemRenderer.ITEM_COUNT_BLIT_OFFSET); // Offset text z position so that it is in front of item
+                    fontRenderer.drawShadow(textMatrixStack, countLabel, x * 2 + 31 - fontRenderer.width(countLabel), y * 2 + 23, ChatFormatting.WHITE.getColor()); // Render count label
+                }
             } else {
                 itemRenderer.renderGuiItemDecorations(fontRenderer, stack, x, y, countLabel); // Render Decorations Normally
             }


### PR DESCRIPTION
This adds small text rendering for overstacked items.
![2022-10-19_18 47 05](https://user-images.githubusercontent.com/55165281/196836979-1cb07b4b-86b1-4330-ab7b-1680c7e6d6c6.png)

The small text rendering only applies to overstacked items. In AE2 or Refined Storage, all items in storage have their count rendered in small text. I was not able to acheive this however, because all item rendering modifications are done through mixins in this mod. Therefore, there is no way to differentiate between an item rendered in the ClientStorage GUI and an item rendered anywhere else.